### PR TITLE
Feat/detect escrow lifecycle functions

### DIFF
--- a/internal/entities/escrow_actions.go
+++ b/internal/entities/escrow_actions.go
@@ -1,0 +1,58 @@
+package entities
+
+// FundEscrowAction represents the parsed payload of a fund_escrow call
+type FundEscrowAction struct {
+	ContractID     string
+	Signer         string
+	ExpectedEscrow *Escrow
+	Amount         uint64
+}
+
+// ReleaseFundsAction represents the parsed payload of a release_funds call
+type ReleaseFundsAction struct {
+	ContractID    string
+	ReleaseSigner string
+}
+
+// UpdateEscrowAction represents the parsed payload of an update_escrow call
+type UpdateEscrowAction struct {
+	ContractID       string
+	PlatformAddress  string
+	EscrowProperties *Escrow
+}
+
+// ExtendContractTTLAction represents the parsed payload of an extend_contract_ttl call
+type ExtendContractTTLAction struct {
+	ContractID      string
+	PlatformAddress string
+	LedgersToExtend uint32
+}
+
+// ChangeMilestoneStatusAction represents the parsed payload of a change_milestone_status call
+type ChangeMilestoneStatusAction struct {
+	ContractID      string
+	MilestoneIndex  uint64
+	NewStatus       string
+	NewEvidence     string
+	ServiceProvider string
+}
+
+// ApproveMilestoneAction represents the parsed payload of an approve_milestone call
+type ApproveMilestoneAction struct {
+	ContractID     string
+	MilestoneIndex uint64
+	Approver       string
+}
+
+// ResolveDisputeAction represents the parsed payload of a resolve_dispute call
+type ResolveDisputeAction struct {
+	ContractID      string
+	DisputeResolver string
+	Distributions   map[string]uint64
+}
+
+// DisputeEscrowAction represents the parsed payload of a dispute_escrow call
+type DisputeEscrowAction struct {
+	ContractID string
+	Signer     string
+}

--- a/internal/indexer/processors/contracts/escrow.go
+++ b/internal/indexer/processors/contracts/escrow.go
@@ -41,18 +41,14 @@ func (p *EscrowProcessor) ProcessTransaction(ctx context.Context, op *processors
 	invokeArgs := invokeHostOp.HostFunction.MustInvokeContract()
 	functionName := invokeArgs.FunctionName
 
-	// Extraer el contract ID del factory
-	factoryContractID, err := p.getContractIDFromAddress(invokeArgs.ContractAddress)
+	contractID, err := p.getContractIDFromAddress(invokeArgs.ContractAddress)
 	if err != nil {
-		return nil, fmt.Errorf("extracting factory contract ID: %w", err)
+		return nil, fmt.Errorf("extracting contract ID: %w", err)
 	}
 
-	//logger := log.Ctx(ctx).WithField("factory_contract", factoryContractID).WithField("function", functionName)
-
-	// Procesar según la función
 	switch functionName {
 	case "tw_new_single_release_escrow":
-		escrow, err := ParseSingleReleaseEscrowArgs(invokeArgs.Args, factoryContractID, p.networkPassphrase)
+		escrow, err := ParseSingleReleaseEscrowArgs(invokeArgs.Args, contractID, p.networkPassphrase)
 		if err != nil {
 			return nil, fmt.Errorf("parsing single release escrow: %w", err)
 		}
@@ -74,7 +70,7 @@ func (p *EscrowProcessor) ProcessTransaction(ctx context.Context, op *processors
 		return []entities.Escrow{*escrow}, nil
 
 	case "tw_new_multi_release_escrow":
-		escrow, err := ParseMultiReleaseEscrowArgs(invokeArgs.Args, factoryContractID, p.networkPassphrase)
+		escrow, err := ParseMultiReleaseEscrowArgs(invokeArgs.Args, contractID, p.networkPassphrase)
 		if err != nil {
 			return nil, fmt.Errorf("parsing multi release escrow: %w", err)
 		}
@@ -94,8 +90,97 @@ func (p *EscrowProcessor) ProcessTransaction(ctx context.Context, op *processors
 
 		return []entities.Escrow{*escrow}, nil
 
+	case "fund_escrow":
+		action, err := ParseFundEscrowArgs(invokeArgs.Args, contractID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing fund_escrow: %w", err)
+		}
+		log.Ctx(ctx).Infof("Fund Escrow detected!")
+		log.Ctx(ctx).Infof("Escrow Contract: %s", action.ContractID)
+		log.Ctx(ctx).Infof("Signer: %s", action.Signer)
+		log.Ctx(ctx).Infof("Amount: %d", action.Amount)
+		return nil, nil
+
+	case "release_funds":
+		action, err := ParseReleaseFundsArgs(invokeArgs.Args, contractID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing release_funds: %w", err)
+		}
+		log.Ctx(ctx).Infof("Release Funds detected!")
+		log.Ctx(ctx).Infof("Escrow Contract: %s", action.ContractID)
+		log.Ctx(ctx).Infof("Release Signer: %s", action.ReleaseSigner)
+		return nil, nil
+
+	case "update_escrow":
+		action, err := ParseUpdateEscrowArgs(invokeArgs.Args, contractID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing update_escrow: %w", err)
+		}
+		log.Ctx(ctx).Infof("Update Escrow detected!")
+		log.Ctx(ctx).Infof("Escrow Contract: %s", action.ContractID)
+		log.Ctx(ctx).Infof("Platform Address: %s", action.PlatformAddress)
+		log.Ctx(ctx).Infof("Updated Title: %s", action.EscrowProperties.Title)
+		return nil, nil
+
+	case "extend_contract_ttl":
+		action, err := ParseExtendContractTTLArgs(invokeArgs.Args, contractID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing extend_contract_ttl: %w", err)
+		}
+		log.Ctx(ctx).Infof("Extend Contract TTL detected!")
+		log.Ctx(ctx).Infof("Escrow Contract: %s", action.ContractID)
+		log.Ctx(ctx).Infof("Platform Address: %s", action.PlatformAddress)
+		log.Ctx(ctx).Infof("Ledgers to Extend: %d", action.LedgersToExtend)
+		return nil, nil
+
+	case "change_milestone_status":
+		action, err := ParseChangeMilestoneStatusArgs(invokeArgs.Args, contractID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing change_milestone_status: %w", err)
+		}
+		log.Ctx(ctx).Infof("Change Milestone Status detected!")
+		log.Ctx(ctx).Infof("Escrow Contract: %s", action.ContractID)
+		log.Ctx(ctx).Infof("Milestone Index: %d", action.MilestoneIndex)
+		log.Ctx(ctx).Infof("New Status: %s", action.NewStatus)
+		log.Ctx(ctx).Infof("New Evidence: %s", action.NewEvidence)
+		log.Ctx(ctx).Infof("Service Provider: %s", action.ServiceProvider)
+		return nil, nil
+
+	case "approve_milestone":
+		action, err := ParseApproveMilestoneArgs(invokeArgs.Args, contractID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing approve_milestone: %w", err)
+		}
+		log.Ctx(ctx).Infof("Approve Milestone detected!")
+		log.Ctx(ctx).Infof("Escrow Contract: %s", action.ContractID)
+		log.Ctx(ctx).Infof("Milestone Index: %d", action.MilestoneIndex)
+		log.Ctx(ctx).Infof("Approver: %s", action.Approver)
+		return nil, nil
+
+	case "resolve_dispute":
+		action, err := ParseResolveDisputeArgs(invokeArgs.Args, contractID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing resolve_dispute: %w", err)
+		}
+		log.Ctx(ctx).Infof("Resolve Dispute detected!")
+		log.Ctx(ctx).Infof("Escrow Contract: %s", action.ContractID)
+		log.Ctx(ctx).Infof("Dispute Resolver: %s", action.DisputeResolver)
+		for addr, amount := range action.Distributions {
+			log.Ctx(ctx).Infof("  Distribution: %s -> %d", addr, amount)
+		}
+		return nil, nil
+
+	case "dispute_escrow":
+		action, err := ParseDisputeEscrowArgs(invokeArgs.Args, contractID)
+		if err != nil {
+			return nil, fmt.Errorf("parsing dispute_escrow: %w", err)
+		}
+		log.Ctx(ctx).Infof("Dispute Escrow detected!")
+		log.Ctx(ctx).Infof("Escrow Contract: %s", action.ContractID)
+		log.Ctx(ctx).Infof("Signer: %s", action.Signer)
+		return nil, nil
+
 	default:
-		// No es una función que nos interese
 		return nil, nil
 	}
 }

--- a/internal/indexer/processors/contracts/escrow_actions_parser.go
+++ b/internal/indexer/processors/contracts/escrow_actions_parser.go
@@ -1,0 +1,218 @@
+package contracts
+
+import (
+	"fmt"
+
+	"github.com/Trustless-Work/Indexer/internal/entities"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// ParseFundEscrowArgs parses arguments for fund_escrow(signer, expected_escrow, amount)
+func ParseFundEscrowArgs(args []xdr.ScVal, contractID string) (*entities.FundEscrowAction, error) {
+	if len(args) < 3 {
+		return nil, fmt.Errorf("fund_escrow: insufficient arguments: expected 3, got %d", len(args))
+	}
+
+	signer, err := extractAddressFromScVal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("fund_escrow: parsing signer address: %w", err)
+	}
+
+	escrow := &entities.Escrow{}
+	if err := parseEscrowData(args[1], escrow); err != nil {
+		return nil, fmt.Errorf("fund_escrow: parsing expected_escrow: %w", err)
+	}
+
+	amount, err := extractI128FromScVal(args[2])
+	if err != nil {
+		return nil, fmt.Errorf("fund_escrow: parsing amount: %w", err)
+	}
+
+	return &entities.FundEscrowAction{
+		ContractID:     contractID,
+		Signer:         signer,
+		ExpectedEscrow: escrow,
+		Amount:         amount,
+	}, nil
+}
+
+// ParseReleaseFundsArgs parses arguments for release_funds(release_signer)
+func ParseReleaseFundsArgs(args []xdr.ScVal, contractID string) (*entities.ReleaseFundsAction, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("release_funds: insufficient arguments: expected 1, got %d", len(args))
+	}
+
+	releaseSigner, err := extractAddressFromScVal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("release_funds: parsing release_signer address: %w", err)
+	}
+
+	return &entities.ReleaseFundsAction{
+		ContractID:    contractID,
+		ReleaseSigner: releaseSigner,
+	}, nil
+}
+
+// ParseUpdateEscrowArgs parses arguments for update_escrow(platform_address, escrow_properties)
+func ParseUpdateEscrowArgs(args []xdr.ScVal, contractID string) (*entities.UpdateEscrowAction, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("update_escrow: insufficient arguments: expected 2, got %d", len(args))
+	}
+
+	platformAddress, err := extractAddressFromScVal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("update_escrow: parsing platform_address: %w", err)
+	}
+
+	escrow := &entities.Escrow{}
+	if err := parseEscrowData(args[1], escrow); err != nil {
+		return nil, fmt.Errorf("update_escrow: parsing escrow_properties: %w", err)
+	}
+
+	return &entities.UpdateEscrowAction{
+		ContractID:       contractID,
+		PlatformAddress:  platformAddress,
+		EscrowProperties: escrow,
+	}, nil
+}
+
+// ParseExtendContractTTLArgs parses arguments for extend_contract_ttl(platform_address, ledgers_to_extend)
+func ParseExtendContractTTLArgs(args []xdr.ScVal, contractID string) (*entities.ExtendContractTTLAction, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("extend_contract_ttl: insufficient arguments: expected 2, got %d", len(args))
+	}
+
+	platformAddress, err := extractAddressFromScVal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("extend_contract_ttl: parsing platform_address: %w", err)
+	}
+
+	ledgersToExtend, err := extractU32FromScVal(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("extend_contract_ttl: parsing ledgers_to_extend: %w", err)
+	}
+
+	return &entities.ExtendContractTTLAction{
+		ContractID:      contractID,
+		PlatformAddress: platformAddress,
+		LedgersToExtend: ledgersToExtend,
+	}, nil
+}
+
+// ParseChangeMilestoneStatusArgs parses arguments for
+// change_milestone_status(milestone_index, new_status, new_evidence, service_provider)
+func ParseChangeMilestoneStatusArgs(args []xdr.ScVal, contractID string) (*entities.ChangeMilestoneStatusAction, error) {
+	if len(args) < 4 {
+		return nil, fmt.Errorf("change_milestone_status: insufficient arguments: expected 4, got %d", len(args))
+	}
+
+	milestoneIndex, err := extractI128FromScVal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("change_milestone_status: parsing milestone_index: %w", err)
+	}
+
+	newStatus, err := extractStringFromScVal(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("change_milestone_status: parsing new_status: %w", err)
+	}
+
+	// new_evidence is Option<String> — None is represented as ScvVoid
+	newEvidence := ""
+	if args[2].Type != xdr.ScValTypeScvVoid {
+		evidence, err := extractStringFromScVal(args[2])
+		if err != nil {
+			return nil, fmt.Errorf("change_milestone_status: parsing new_evidence: %w", err)
+		}
+		newEvidence = evidence
+	}
+
+	serviceProvider, err := extractAddressFromScVal(args[3])
+	if err != nil {
+		return nil, fmt.Errorf("change_milestone_status: parsing service_provider: %w", err)
+	}
+
+	return &entities.ChangeMilestoneStatusAction{
+		ContractID:      contractID,
+		MilestoneIndex:  milestoneIndex,
+		NewStatus:       newStatus,
+		NewEvidence:     newEvidence,
+		ServiceProvider: serviceProvider,
+	}, nil
+}
+
+// ParseApproveMilestoneArgs parses arguments for approve_milestone(milestone_index, approver)
+func ParseApproveMilestoneArgs(args []xdr.ScVal, contractID string) (*entities.ApproveMilestoneAction, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("approve_milestone: insufficient arguments: expected 2, got %d", len(args))
+	}
+
+	milestoneIndex, err := extractI128FromScVal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("approve_milestone: parsing milestone_index: %w", err)
+	}
+
+	approver, err := extractAddressFromScVal(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("approve_milestone: parsing approver: %w", err)
+	}
+
+	return &entities.ApproveMilestoneAction{
+		ContractID:     contractID,
+		MilestoneIndex: milestoneIndex,
+		Approver:       approver,
+	}, nil
+}
+
+// ParseResolveDisputeArgs parses arguments for resolve_dispute(dispute_resolver, distributions)
+func ParseResolveDisputeArgs(args []xdr.ScVal, contractID string) (*entities.ResolveDisputeAction, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("resolve_dispute: insufficient arguments: expected 2, got %d", len(args))
+	}
+
+	disputeResolver, err := extractAddressFromScVal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("resolve_dispute: parsing dispute_resolver: %w", err)
+	}
+
+	// distributions is Map<Address, i128> — keys are Addresses, not Symbols
+	entries, err := extractMapFromScVal(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("resolve_dispute: parsing distributions map: %w", err)
+	}
+
+	distributions := make(map[string]uint64, len(entries))
+	for i, entry := range entries {
+		addr, err := extractAddressFromScVal(entry.Key)
+		if err != nil {
+			return nil, fmt.Errorf("resolve_dispute: parsing distribution address[%d]: %w", i, err)
+		}
+		amount, err := extractI128FromScVal(entry.Val)
+		if err != nil {
+			return nil, fmt.Errorf("resolve_dispute: parsing distribution amount[%d]: %w", i, err)
+		}
+		distributions[addr] = amount
+	}
+
+	return &entities.ResolveDisputeAction{
+		ContractID:      contractID,
+		DisputeResolver: disputeResolver,
+		Distributions:   distributions,
+	}, nil
+}
+
+// ParseDisputeEscrowArgs parses arguments for dispute_escrow(signer)
+func ParseDisputeEscrowArgs(args []xdr.ScVal, contractID string) (*entities.DisputeEscrowAction, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("dispute_escrow: insufficient arguments: expected 1, got %d", len(args))
+	}
+
+	signer, err := extractAddressFromScVal(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("dispute_escrow: parsing signer address: %w", err)
+	}
+
+	return &entities.DisputeEscrowAction{
+		ContractID: contractID,
+		Signer:     signer,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- Add detection and logging for 8 additional escrow contract functions: `fund_escrow`, `release_funds`, `update_escrow`, `extend_contract_ttl`, `change_milestone_status`, `approve_milestone`, `resolve_dispute`, and `dispute_escrow`
- Each function has its own dedicated parser with distinct payload handling (no generic handler)
- Log output matches existing format using `log.Ctx(ctx).Infof()` — no database persistence

## Changes
1. **`internal/entities/escrow_actions.go`** (new) — 8 entity structs for lifecycle payloads
2. **`internal/indexer/processors/contracts/escrow_actions_parser.go`** (new) — 8 parser functions with XDR argument extraction, including `Option<String>` and `Map<Address, i128>` handling
3. **`internal/indexer/processors/contracts/escrow.go`** (modified) — 8 new switch cases + rename `factoryContractID` → `contractID`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Run indexer against testnet and trigger each of the 8 functions via [escrow-maker](https://escrow-maker.vercel.app/) to verify log output

Closes Trustless-Work/Indexer#4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple escrow actions: fund escrow, release funds, update escrow, extend contract TTL, change/approve milestone status, dispute and resolve disputes.
* **Chores**
  * Improved processing and logging for escrow workflows to surface action details and parsing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->