### PR TITLE
fix(state): refuse to publish removals when a batch answers empty (audit A3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ Served on `HEALTH_PORT` (default 8080) while the loop runs:
   monitors here.
 - `GET /status` — the incident numbers: cursor, ledger age, active RPC
   endpoint (`rpc_endpoint`), pause state, escrows tracked, publish
-  totals, recorded gaps, uptime.
+  totals, recorded gaps, `suppressed_removals`, uptime.
+  `suppressed_removals` above zero means an RPC endpoint answered with an
+  empty result set and the plausibility guard stopped it from publishing
+  the whole batch as removed — look at the endpoint, not at the escrows.
 - `GET /metrics` — the same numbers in Prometheus format, plus the
   ledger-fetch duration summary.
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -39,6 +39,10 @@ type Progress struct {
 	Events         int
 	StateChanges   int
 	Gaps           int
+	// SuppressedRemovals is the running count of removals the state
+	// detector refused to publish because their batch failed the
+	// plausibility guard (an RPC answering with an empty result set).
+	SuppressedRemovals int
 }
 
 // Status is the read-side snapshot served by /status. Ages are computed
@@ -72,6 +76,10 @@ type Status struct {
 	EventsPublished       int `json:"events_published_total"`
 	StateChangesPublished int `json:"state_changes_published_total"`
 	Gaps                  int `json:"gaps_recorded"`
+	// SuppressedRemovals climbing means an RPC endpoint is answering with
+	// empty results and the guard is protecting the read-model from a
+	// mass false removal. Steady at zero is the healthy state.
+	SuppressedRemovals int `json:"suppressed_removals"`
 
 	UptimeSeconds float64 `json:"uptime_seconds"`
 }
@@ -82,19 +90,20 @@ type Tracker struct {
 	// now is injected for tests; time.Now in production.
 	now func() time.Time
 
-	mu              sync.Mutex
-	network         string
-	rpcEndpoint     string
-	startedAt       time.Time
-	currentLedger   uint32
-	ledgerClosedAt  time.Time
-	lastProcessedAt time.Time
-	lastDuration    time.Duration
-	knownEscrows    int
-	eventsTotal     int
-	statesTotal     int
-	gaps            int
-	pausedUntil     time.Time
+	mu                 sync.Mutex
+	network            string
+	rpcEndpoint        string
+	startedAt          time.Time
+	currentLedger      uint32
+	ledgerClosedAt     time.Time
+	lastProcessedAt    time.Time
+	lastDuration       time.Duration
+	knownEscrows       int
+	eventsTotal        int
+	statesTotal        int
+	gaps               int
+	suppressedRemovals int
+	pausedUntil        time.Time
 }
 
 // NewTracker builds a Tracker for the given network label.
@@ -137,6 +146,7 @@ func (t *Tracker) RecordLedger(p Progress) {
 	t.eventsTotal += p.Events
 	t.statesTotal += p.StateChanges
 	t.gaps = p.Gaps
+	t.suppressedRemovals = p.SuppressedRemovals
 }
 
 // Snapshot returns the current Status.
@@ -159,6 +169,7 @@ func (t *Tracker) Snapshot() Status {
 		EventsPublished:       t.eventsTotal,
 		StateChangesPublished: t.statesTotal,
 		Gaps:                  t.gaps,
+		SuppressedRemovals:    t.suppressedRemovals,
 		UptimeSeconds:         now.Sub(t.startedAt).Seconds(),
 	}
 	if s.Paused {

--- a/internal/health/metrics.go
+++ b/internal/health/metrics.go
@@ -41,6 +41,7 @@ type trackerCollector struct {
 	eventsTotal   *prometheus.Desc
 	statesTotal   *prometheus.Desc
 	gaps          *prometheus.Desc
+	suppressed    *prometheus.Desc
 	ready         *prometheus.Desc
 	paused        *prometheus.Desc
 	uptime        *prometheus.Desc
@@ -64,6 +65,7 @@ func newTrackerCollector(t *Tracker) *trackerCollector {
 		eventsTotal:   desc("events_published_total", "Escrow events and deposits published since boot."),
 		statesTotal:   desc("state_changes_published_total", "State snapshots published since boot (activity + sweep + commands)."),
 		gaps:          desc("gaps_recorded", "Ledger ranges knowingly skipped and recorded as gap evidence."),
+		suppressed:    desc("suppressed_removals_total", "Removals withheld because their batch failed the plausibility guard (an RPC answering with an empty result set). Anything above zero warrants looking at the RPC endpoint."),
 		ready:         desc("ready", "1 when the loop is demonstrably advancing (the /readyz semantic)."),
 		paused:        desc("paused", "1 while an operator pause is in effect."),
 		uptime:        desc("uptime_seconds", "Process uptime."),
@@ -73,7 +75,8 @@ func newTrackerCollector(t *Tracker) *trackerCollector {
 func (c *trackerCollector) Describe(ch chan<- *prometheus.Desc) {
 	for _, d := range []*prometheus.Desc{
 		c.currentLedger, c.ledgerAge, c.sinceLast, c.knownEscrows,
-		c.eventsTotal, c.statesTotal, c.gaps, c.ready, c.paused, c.uptime,
+		c.eventsTotal, c.statesTotal, c.gaps, c.suppressed, c.ready, c.paused,
+		c.uptime,
 	} {
 		ch <- d
 	}
@@ -101,6 +104,7 @@ func (c *trackerCollector) Collect(ch chan<- prometheus.Metric) {
 	counter(c.eventsTotal, float64(s.EventsPublished))
 	counter(c.statesTotal, float64(s.StateChangesPublished))
 	gauge(c.gaps, float64(s.Gaps))
+	counter(c.suppressed, float64(s.SuppressedRemovals))
 	gauge(c.ready, b2f(s.Ready))
 	gauge(c.paused, b2f(s.Paused))
 	gauge(c.uptime, s.UptimeSeconds)

--- a/internal/indexer/processors/escrow_state.go
+++ b/internal/indexer/processors/escrow_state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Trustless-Work/Indexer/internal/indexer/registry"
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
@@ -33,6 +34,34 @@ const maxLedgerEntryKeysPerRequest = MaxLedgerEntryKeys
 // candidateKeysPerEscrow is how many LedgerKeys escrowStateLedgerKeys
 // builds for an escrow whose storage shape we have not learned yet.
 const candidateKeysPerEscrow = 4
+
+// The mass-removal guard. An RPC that answers 200 with an empty (or
+// truncated) entry list is INDISTINGUISHABLE from one reporting that none
+// of the requested entries exist — both are "no entry came back". Without
+// a guard the second reading wins and every escrow in the batch is
+// published as removed, which the consumer applies to real rows.
+//
+// So we judge by plausibility instead. Escrows expire and get withdrawn
+// INDEPENDENTLY, and the sweep walks the watchlist in contract-id order,
+// which bears no relation to creation time or TTL. A batch where most
+// entries vanished at once is therefore a broken provider, not the chain.
+//
+// The asymmetry decides the tie: losing one reconciliation pass costs a
+// few seconds and the next pass fixes it, while marking the watchlist
+// removed corrupts the read-model for every escrow at once.
+const (
+	// removalGuardMinBatch is the smallest batch the guard applies to.
+	// Below it, an all-absent answer is perfectly organic — the per-ledger
+	// activity path asks about the one or two escrows that just moved, and
+	// one of them really can have just been withdrawn.
+	removalGuardMinBatch = 10
+	// removalGuardMaxAbsentRatio is how much of a batch may come back
+	// empty before we stop believing it. Above half of a batch of ten or
+	// more disappearing in a single ledger has no organic explanation,
+	// while a genuinely large cleanup spread across the rotation stays
+	// well under it and is reported normally.
+	removalGuardMaxAbsentRatio = 0.5
+)
 
 // EscrowStateChange is the current state of one known escrow's
 // DataKey::Escrow entry as fetched from the Soroban RPC right after a
@@ -75,6 +104,11 @@ type EscrowStateDetector struct {
 	// detector lives on the single ingest goroutine (same invariant as
 	// the registry writes).
 	learned map[string]string
+	// suppressedRemovals counts removals withheld by the plausibility
+	// guard since boot. Surfaced through SuppressedRemovals so the loop
+	// can report it: a guard that fires silently would trade one
+	// invisible failure for another.
+	suppressedRemovals int
 }
 
 // NewEscrowStateDetector builds a state detector that queries the given
@@ -141,8 +175,47 @@ func (d *EscrowStateDetector) fetchStates(ctx context.Context, escrowIDs []strin
 
 	// Order matters: judge absence over the UNFILTERED set (an unchanged
 	// escrow dropped by the filter must not look removed), then filter.
+	missing := missingFrom(requested, changes)
+	if isImplausibleRemovalBatch(len(requested), len(missing)) {
+		d.suppressedRemovals += len(missing)
+		log.Ctx(ctx).Errorf(
+			"Refusing to publish %d removals at ledger %d: %d of %d escrows in this batch answered with no entry at all. "+
+				"Escrows do not disappear together, so this reads as an RPC endpoint returning an empty or truncated result, not as on-chain removals. "+
+				"State updates from the same response are still published; the next sweep pass re-checks these escrows. "+
+				"If it repeats, the endpoint (%s) is the thing to look at.",
+			len(missing), ledgerSeq, len(missing), len(requested), d.rpcName())
+		sortByEscrowID(changes)
+		return filterUnchanged(changes, modifiedSince), nil
+	}
+
 	all := appendRemoved(requested, changes, ledgerSeq, ledgerClosedAt)
 	return filterUnchanged(all, modifiedSince), nil
+}
+
+// isImplausibleRemovalBatch reports whether a batch answering with this
+// many absences should be read as a provider fault rather than as removals.
+// Pure, so the policy can be unit-tested without an RPC.
+func isImplausibleRemovalBatch(requested, missing int) bool {
+	if requested < removalGuardMinBatch {
+		return false
+	}
+	return float64(missing) > float64(requested)*removalGuardMaxAbsentRatio
+}
+
+// SuppressedRemovals counts the removals this detector refused to publish
+// because their batch failed the plausibility guard. Monotonic since boot;
+// the loop reports it so /status and Prometheus surface it. A number that
+// keeps climbing means an RPC endpoint is answering with empty results.
+func (d *EscrowStateDetector) SuppressedRemovals() int { return d.suppressedRemovals }
+
+// rpcName describes the RPC source for the guard's log line, when it can.
+// The detector reads through an interface precisely so it does not care
+// which endpoint answers, so this is best-effort.
+func (d *EscrowStateDetector) rpcName() string {
+	if named, ok := d.rpc.(interface{ CurrentHost() string }); ok {
+		return named.CurrentHost()
+	}
+	return "current RPC endpoint"
 }
 
 // queryEntries turns escrow ids into getLedgerEntries calls — one learned
@@ -259,8 +332,15 @@ func appendRemoved(requested []string, present []EscrowStateChange, ledgerSeq ui
 		})
 	}
 	// Keep the stable by-EscrowID order buildStateChanges promises.
-	sort.Slice(out, func(i, j int) bool { return out[i].EscrowID < out[j].EscrowID })
+	sortByEscrowID(out)
 	return out
+}
+
+// sortByEscrowID imposes the stable publish order every path promises.
+// Shared so the guarded path, which skips appendRemoved, still returns the
+// merged relearn results in the same order as the normal one.
+func sortByEscrowID(changes []EscrowStateChange) {
+	sort.Slice(changes, func(i, j int) bool { return changes[i].EscrowID < changes[j].EscrowID })
 }
 
 // chunkStrings splits s into consecutive slices of at most size elements.

--- a/internal/indexer/processors/escrow_state_removal_guard_test.go
+++ b/internal/indexer/processors/escrow_state_removal_guard_test.go
@@ -1,0 +1,148 @@
+package processors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Trustless-Work/Indexer/internal/indexer/registry"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/strkey"
+)
+
+// emptyRPC answers every getLedgerEntries with a successful, EMPTY result —
+// the shape a degraded provider produces (a node still resyncing, a load
+// balancer routing to a replica without the data, a silently truncated
+// response). It is indistinguishable, on the wire, from "none of these
+// entries exist", which is precisely what makes the guard necessary.
+type emptyRPC struct{ calls int }
+
+func (r *emptyRPC) GetLedgerEntries(
+	context.Context,
+	protocol.GetLedgerEntriesRequest,
+) (protocol.GetLedgerEntriesResponse, error) {
+	r.calls++
+	return protocol.GetLedgerEntriesResponse{}, nil
+}
+
+// contractIDs mints n distinct, well-formed C... strkeys so the detector
+// actually builds ledger keys for them and counts them as requested.
+func contractIDs(t *testing.T, n int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	for i := range n {
+		var raw [32]byte
+		raw[0], raw[1] = byte(i+1), byte(i>>8)
+		id, err := strkey.Encode(strkey.VersionByteContract, raw[:])
+		if err != nil {
+			t.Fatalf("encode contract id %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func detectorOver(t *testing.T, rpc LedgerEntryGetter, ids []string) *EscrowStateDetector {
+	t.Helper()
+	reg, err := registry.New(nil)
+	if err != nil {
+		t.Fatalf("registry.New: %v", err)
+	}
+	reg.Seed(ids)
+	return NewEscrowStateDetector(rpc, reg)
+}
+
+// The regression this whole guard exists for. Before it, one empty response
+// to a sweep batch published a "removed" per escrow, and the consumer
+// applied every one of them to real rows — the sweep rotating over the
+// watchlist would have wiped the read-model in a handful of ledgers.
+func TestFetchStates_EmptyRPCResponseRemovesNobody(t *testing.T) {
+	ids := contractIDs(t, 20)
+	rpc := &emptyRPC{}
+	d := detectorOver(t, rpc, ids)
+
+	changes, err := d.FetchStates(context.Background(), ids, 100, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("FetchStates: %v", err)
+	}
+
+	if len(changes) != 0 {
+		t.Fatalf("published %d changes from an empty response, want 0: %+v", len(changes), changes)
+	}
+	for _, c := range changes {
+		if c.StateChangeType == "removed" {
+			t.Fatalf("published a removal for %s off an empty response", c.EscrowID)
+		}
+	}
+	if rpc.calls == 0 {
+		t.Fatal("the detector never queried the RPC; the test is not exercising the path")
+	}
+}
+
+// The guard has to leave a number behind: a silent guard would trade one
+// invisible failure (mass false removal) for another (nobody notices the
+// provider is broken).
+func TestFetchStates_SuppressedRemovalsIsCounted(t *testing.T) {
+	ids := contractIDs(t, 20)
+	d := detectorOver(t, &emptyRPC{}, ids)
+
+	if got := d.SuppressedRemovals(); got != 0 {
+		t.Fatalf("counter starts at %d, want 0", got)
+	}
+	if _, err := d.FetchStates(context.Background(), ids, 100, time.Now().UTC()); err != nil {
+		t.Fatalf("FetchStates: %v", err)
+	}
+	if got := d.SuppressedRemovals(); got != len(ids) {
+		t.Errorf("suppressed = %d, want %d", got, len(ids))
+	}
+}
+
+// The guard must not break the feature it protects. A small batch is the
+// per-ledger activity path, where one escrow really can have just been
+// withdrawn, so absence there is still reported as a removal.
+func TestFetchStates_SmallBatchStillReportsRemovals(t *testing.T) {
+	ids := contractIDs(t, 3)
+	d := detectorOver(t, &emptyRPC{}, ids)
+
+	changes, err := d.FetchStates(context.Background(), ids, 100, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("FetchStates: %v", err)
+	}
+
+	if len(changes) != len(ids) {
+		t.Fatalf("changes = %d, want %d removals", len(changes), len(ids))
+	}
+	for _, c := range changes {
+		if c.StateChangeType != "removed" {
+			t.Errorf("%s = %q, want removed", c.EscrowID, c.StateChangeType)
+		}
+	}
+	if got := d.SuppressedRemovals(); got != 0 {
+		t.Errorf("suppressed = %d, want 0 — the guard must not arm on a small batch", got)
+	}
+}
+
+func TestIsImplausibleRemovalBatch(t *testing.T) {
+	cases := []struct {
+		name               string
+		requested, missing int
+		want               bool
+	}{
+		{"small batch, all gone, is organic", 3, 3, false},
+		{"just under the minimum batch", removalGuardMinBatch - 1, removalGuardMinBatch - 1, false},
+		{"at the minimum, all gone", removalGuardMinBatch, removalGuardMinBatch, true},
+		{"big batch, all gone", 200, 200, true},
+		{"big batch, exactly half gone, still believed", 200, 100, false},
+		{"big batch, just over half gone", 200, 101, true},
+		{"big batch, a realistic handful gone", 200, 3, false},
+		{"nothing missing", 200, 0, false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isImplausibleRemovalBatch(tt.requested, tt.missing); got != tt.want {
+				t.Errorf("isImplausibleRemovalBatch(%d, %d) = %v, want %v",
+					tt.requested, tt.missing, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -501,6 +501,9 @@ func Ingest(ctx context.Context, cfg *config.Config) error {
 			Events:         len(facts),
 			StateChanges:   len(states) + sweepPublished,
 			Gaps:           len(gaps),
+			// Absolute since boot, like Gaps: a guard that fires without
+			// leaving a number behind would be a silent failure of its own.
+			SuppressedRemovals: stateDetector.SuppressedRemovals(),
 		})
 		heartbeat.Beat(ctx)
 


### PR DESCRIPTION
Closes audit finding A3 (TWH-731).

## The hole

`appendRemoved` emitted a `removed` state change for every requested escrow with no entry in the RPC response. An RPC answering 200 with an empty or truncated list is **indistinguishable on the wire** from one reporting that none of those entries exist — both are "no entry came back" — and the detector took the second reading.

The sweep asks about up to 200 escrows per ledger and rotates over the whole watchlist, and the consumer applies `removed` with `updateMany` against real rows. A provider glitch during a failover — precisely when the least-exercised fallback endpoint is in use — could have marked the entire read-model removed within a handful of ledgers.

The code already knew the stakes: "a false removed is the one mistake this detector must never make". The existing guard only covered a learned-key shape change, not a wholesale empty answer.

## The fix

Absence is judged by plausibility. Escrows expire and get withdrawn independently, and the sweep walks the watchlist in contract-id order, which bears no relation to creation time or TTL. More than half of a batch of ten or more vanishing at once has no organic explanation.

- **Proportion, not exactly-empty** — this also catches the truncated response, where a provider caps at 100 entries of a 200-key request and the remainder would read as removed.
- **Minimum batch of 10** — below that an all-absent answer is organic: the per-ledger activity path asks about the one or two escrows that just moved, and one really can have just been withdrawn. The guard must not break what it protects.
- **Updates still publish** — only the inferred absence is untrustworthy.
- **Skip, not fail** — an RPC error already has its own handling; this covers a successful response we do not believe, and killing the loop over a provider fault would be the wrong trade exactly when failover should be rotating.

## Observability

A guard that fires silently trades an invisible failure for another. `SuppressedRemovals` is reported every ledger like `Gaps`, exposed as `suppressed_removals` on `/status` and `indexer_suppressed_removals_total` in Prometheus. Anything above zero points at the endpoint, not at the escrows — and the log line says so.

## What this deliberately does not solve

A genuine mass expiry would also be blocked. Accepted: the sweep order bears no relation to creation time, so a bulk-created cohort spreads across the rotation and stays under the threshold. If it ever happens it surfaces as a repeated ERROR with the counter climbing, which is the signal for a human to judge it. Better that a rare case needs judgement than that a common failure corrupts data on its own.

## Verification

`gofmt`, `go vet`, `go build`, `go test` green. New `escrow_state_removal_guard_test.go` adds the coverage that was missing — there were cases for one escrow absent and for none absent, never for all of them — plus a fake RPC answering with an empty result set, the seam this package lacked to exercise `fetchStates` end to end.