### PR TITLE
fix(sink): wait on each message own confirmation, not the next one (audit A2)

### DIFF
--- a/internal/ingest/backpressure.go
+++ b/internal/ingest/backpressure.go
@@ -24,8 +24,11 @@ const (
 
 // backpressureSink wraps a sink.Sink with the loop's retry policy (the
 // Sink contract says the caller owns retries). Only ErrSinkPublishRejected
-// — a nack from a full queue, or a confirm timeout — is retried, with
-// 1s→60s backoff and no attempt cap: the broker is alive and will drain.
+// — a nack from a full queue — is retried, with 1s→60s backoff and no
+// attempt cap: the broker is alive and will drain. A slow broker never
+// reaches here: the sink waits for each message's own confirmation rather
+// than timing out (audit A2), so this path now sees genuine rejections
+// only.
 // Everything else passes through as fatal, each for its own reason:
 //
 //   - events.ErrEnvelopeInvalid: a bug in the producer, never transient.

--- a/internal/sink/rabbitmq/config.go
+++ b/internal/sink/rabbitmq/config.go
@@ -1,7 +1,5 @@
 package rabbitmq
 
-import "time"
-
 // Config holds what the RabbitMQ sink needs. It is populated by the
 // factory from the global config; the sink never reads env vars.
 type Config struct {
@@ -13,16 +11,7 @@ type Config struct {
 	Exchange string
 	// PublisherConfirms enables RabbitMQ publisher confirms (at-least-once):
 	// Publish blocks on a positive broker ack before returning success.
-	// Recommended for production.
+	// Recommended for production — without it a publish is fire-and-forget
+	// and the cursor advances over anything the broker quietly drops.
 	PublisherConfirms bool
-	// PublishConfirmTimeout bounds how long Publish waits for an ack when
-	// PublisherConfirms is enabled. Defaults to 10s when zero.
-	PublishConfirmTimeout time.Duration
-}
-
-func (c Config) withDefaults() Config {
-	if c.PublishConfirmTimeout == 0 {
-		c.PublishConfirmTimeout = 10 * time.Second
-	}
-	return c
 }

--- a/internal/sink/rabbitmq/rabbitmq.go
+++ b/internal/sink/rabbitmq/rabbitmq.go
@@ -1,15 +1,19 @@
 // Package rabbitmq publishes envelopes to a RabbitMQ topic exchange, one
 // message per envelope. With publisher confirms enabled (the production
-// default), Publish blocks on a positive broker ack before returning
-// success — that ack is what justifies advancing the cursor downstream.
+// default), Publish blocks on a positive broker ack for THAT message
+// before returning success — that ack is what justifies advancing the
+// cursor downstream.
 //
 // The routing key comes from the envelope (stellar.<net>.escrow.<type>.<kind>).
 // The sink owns only the exchange declaration; consumers declare and bind
 // their own queues.
 //
-// Concurrency: amqp.Channel is not safe for concurrent use and confirms
-// arrive in publish order, so Publish is serialized with a mutex. The
-// intended caller is the single-goroutine ingest loop.
+// Concurrency: amqp.Channel is not safe for concurrent use, so Publish is
+// serialized with a mutex. Note this is the ONLY reason left: confirms no
+// longer have to arrive in publish order, because each publish now waits
+// on its own DeferredConfirmation rather than on the next confirmation to
+// appear on a shared channel (audit A2). The intended caller is still the
+// single-goroutine ingest loop.
 package rabbitmq
 
 import (
@@ -26,20 +30,93 @@ import (
 	"github.com/Trustless-Work/Indexer/internal/sink"
 )
 
+// confirmWarnEvery paces the "still waiting" warning while a publish is
+// held on the broker. Waiting is not an error — it is backpressure, and
+// the loop deliberately holds the cursor rather than advance past an
+// unconfirmed message — but a silent indefinite wait would be
+// indistinguishable from a hang.
+const confirmWarnEvery = 30 * time.Second
+
+// returnsBuffer sizes the basic.return notification channel. The library
+// delivers returns with a BLOCKING send, so an undersized buffer stalls
+// the connection's dispatcher — the same hazard that made the old
+// NotifyPublish listener dangerous. Returns are rare (they mean broken
+// topology, which is fatal here), so a small buffer is plenty; what
+// matters is that it is never zero-slack.
+const returnsBuffer = 8
+
+// confirmation is one publish's own receipt, replacing the positional
+// "read the next confirmation off a shared channel" that lost data when
+// the stream desynchronised (audit A2). *amqp.DeferredConfirmation
+// satisfies this as-is — no wrapper needed — while a fake can resolve it
+// on demand, which is what makes this path testable at all.
+type confirmation interface {
+	// Done closes once the broker has answered for THIS message.
+	Done() <-chan struct{}
+	// Acked reports the answer. Only meaningful after Done is closed.
+	Acked() bool
+}
+
+// publishChannel is the slice of *amqp.Channel the sink needs. Kept
+// deliberately tiny: everything else the channel does (declaring the
+// exchange, enabling confirm mode, registering notifications) is boot
+// wiring that runs once in connect and is not worth abstracting.
+type publishChannel interface {
+	publish(ctx context.Context, routingKey string, msg amqp.Publishing) (confirmation, error)
+	// Close is the odd one out in casing, on purpose: naming it close
+	// would shadow the builtin.
+	Close() error
+}
+
+// amqpChannel adapts *amqp.Channel to publishChannel. The exchange is
+// fixed for the sink's lifetime, so it lives here instead of being passed
+// on every publish.
+type amqpChannel struct {
+	ch       *amqp.Channel
+	exchange string
+}
+
+// publish sends one message and returns its receipt, or a nil
+// confirmation when the channel is not in confirm mode.
+func (a amqpChannel) publish(ctx context.Context, routingKey string, msg amqp.Publishing) (confirmation, error) {
+	// mandatory=true is an invariant of this sink, not a caller's choice:
+	// an envelope that matches NO queue binding must come back as a
+	// basic.return instead of being dropped silently. Before it, publishing
+	// with the consumer's queue missing confirmed fine and the cursor
+	// advanced over lost data (audit Sprint 5).
+	dc, err := a.ch.PublishWithDeferredConfirmWithContext(ctx, a.exchange, routingKey, true, false, msg)
+	if err != nil {
+		return nil, err
+	}
+	if dc == nil {
+		// Confirm mode is off, so the broker will never answer. The
+		// library reports that by handing back a nil confirmation, which
+		// is why this needs no second source of truth to keep in sync.
+		//
+		// Returning a literal nil — NOT dc — matters: `return dc, nil`
+		// would wrap a nil pointer in a NON-nil interface, sailing past
+		// the caller's nil check and panicking on the first method call.
+		return nil, nil
+	}
+	return dc, nil
+}
+
+func (a amqpChannel) Close() error { return a.ch.Close() }
+
 // Sink delivers envelopes to a RabbitMQ topic exchange.
 type Sink struct {
 	cfg Config
 
-	mu       sync.Mutex
-	conn     *amqp.Connection
-	channel  *amqp.Channel
-	confirms chan amqp.Confirmation // nil when PublisherConfirms is false
+	mu   sync.Mutex
+	conn *amqp.Connection
+	ch   publishChannel
 	// returns receives basic.return frames for unroutable mandatory
 	// publishes. CRITICAL subtlety: the broker CONFIRMS a returned message
-	// (it was received, just not routed), so the confirm alone would let
-	// the cursor advance over silently-dropped data — exactly the loss
-	// mandatory publishing exists to prevent. Publish checks this channel
-	// after every confirm.
+	// (it was received, just not routed), so the ack alone would let the
+	// cursor advance over silently-dropped data — exactly the loss
+	// mandatory publishing exists to prevent. Publish checks this after
+	// every confirm, matching on MessageId so a stray return can never be
+	// charged to the wrong envelope.
 	returns chan amqp.Return
 }
 
@@ -54,7 +131,7 @@ func New(cfg Config) (*Sink, error) {
 	if cfg.Exchange == "" {
 		return nil, fmt.Errorf("rabbitmq: Exchange is required")
 	}
-	s := &Sink{cfg: cfg.withDefaults()}
+	s := &Sink{cfg: cfg}
 	if err := s.connect(); err != nil {
 		return nil, fmt.Errorf("rabbitmq: initial connect: %w", err)
 	}
@@ -62,7 +139,7 @@ func New(cfg Config) (*Sink, error) {
 }
 
 // connect dials, opens a channel, declares the durable topic exchange and
-// (when configured) registers a publisher-confirm listener.
+// (when configured) puts the channel into confirm mode.
 func (s *Sink) connect() error {
 	conn, err := amqp.Dial(s.cfg.URL)
 	if err != nil {
@@ -81,27 +158,25 @@ func (s *Sink) connect() error {
 		return fmt.Errorf("%w: declare exchange %q: %v", sink.ErrSinkUnavailable, s.cfg.Exchange, err)
 	}
 
-	var confirms chan amqp.Confirmation
 	if s.cfg.PublisherConfirms {
 		if err := ch.Confirm(false); err != nil {
 			_ = ch.Close()
 			_ = conn.Close()
 			return fmt.Errorf("%w: enable confirms: %v", sink.ErrSinkUnavailable, err)
 		}
-		// Buffer of 1: Publish is serialized, so at most one confirm is
-		// in flight at a time.
-		confirms = ch.NotifyPublish(make(chan amqp.Confirmation, 1))
 	}
 
-	// Buffer of 1 for the same serialization reason. The library delivers
-	// the basic.return BEFORE the confirm of the same publish (frames are
-	// dispatched in wire order), so by the time Publish sees the confirm,
-	// any return for that message is already buffered here.
-	returns := ch.NotifyReturn(make(chan amqp.Return, 1))
+	// No NotifyPublish listener on purpose. Deferred confirmations carry
+	// each result to its own publisher, and registering a listener would
+	// re-create the hazard this design removes: the library delivers
+	// confirmations with a BLOCKING send, so a listener nobody is draining
+	// stalls the connection's dispatcher, kills the heartbeats and drops
+	// the connection — precisely while a publish sits in backoff.
+	returns := ch.NotifyReturn(make(chan amqp.Return, returnsBuffer))
 
 	// Surface broker-wide flow control (memory/disk alarm) in the logs the
 	// moment it happens: without this, a blocked broker looks like a bare
-	// confirm timeout and the real cause is invisible. The goroutine ends
+	// slow confirm and the real cause is invisible. The goroutine ends
 	// when the connection closes (the library closes the channel).
 	blocked := conn.NotifyBlocked(make(chan amqp.Blocking, 1))
 	go func() {
@@ -115,15 +190,13 @@ func (s *Sink) connect() error {
 	}()
 
 	s.conn = conn
-	s.channel = ch
-	s.confirms = confirms
+	s.ch = amqpChannel{ch: ch, exchange: s.cfg.Exchange}
 	s.returns = returns
 	return nil
 }
 
-// Publish marshals env to JSON and publishes it to the exchange under the
-// envelope's routing key. When confirms are enabled, it blocks on the
-// broker ack (bounded by PublishConfirmTimeout).
+// Publish marshals env to JSON and publishes it under the envelope's
+// routing key, then blocks until the broker answers for THAT message.
 func (s *Sink) Publish(ctx context.Context, env events.Envelope) error {
 	if err := env.Validate(); err != nil {
 		return err // wrapped events.ErrEnvelopeInvalid
@@ -137,46 +210,85 @@ func (s *Sink) Publish(ctx context.Context, env events.Envelope) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	pub := amqp.Publishing{
+	confirm, err := s.ch.publish(ctx, env.RoutingKey(), amqp.Publishing{
 		ContentType:  "application/json",
 		DeliveryMode: amqp.Persistent,
 		MessageId:    env.MessageID,
 		Timestamp:    env.PublishedAt,
 		Body:         body,
-	}
-	// mandatory=true: an envelope that matches NO queue binding comes back
-	// as a basic.return instead of being dropped silently. Before this,
-	// publishing with the consumer's queue missing confirmed fine and the
-	// cursor advanced over lost data (audit Sprint 5).
-	if err := s.channel.PublishWithContext(ctx, s.cfg.Exchange, env.RoutingKey(), true, false, pub); err != nil {
+	})
+	if err != nil {
 		return fmt.Errorf("%w: publishing %s: %v", sink.ErrSinkUnavailable, env.MessageID, err)
 	}
-
-	if s.confirms == nil {
-		return nil
+	if confirm == nil {
+		return nil // confirms disabled: nothing to wait on
 	}
 
-	select {
-	case confirm := <-s.confirms:
-		if !confirm.Ack {
-			return fmt.Errorf("%w: broker nacked %s", sink.ErrSinkPublishRejected, env.MessageID)
-		}
-		// A returned message is CONFIRMED (received but unroutable), so
-		// the ack alone is not success. Publish is serialized, so any
-		// buffered return belongs to this publish. Wrapped as
-		// ErrSinkUnroutable — NOT ErrSinkPublishRejected — because broken
-		// topology must not be retried like backpressure.
+	if err := s.awaitConfirm(ctx, confirm, env.MessageID); err != nil {
+		return err
+	}
+	return s.checkReturned(ctx, env.MessageID)
+}
+
+// awaitConfirm blocks until this message's own confirmation resolves.
+//
+// There is deliberately NO timeout. A deferred confirmation ALWAYS
+// resolves: by a broker ack, by a nack, or — when the channel or
+// connection dies — as a nack, because Channel.shutdown nacks everything
+// still pending. So the wait cannot hang, and bounding it artificially is
+// what desynchronised the old shared confirmation stream: abandoning a
+// wait left the late answer to be charged to the next message forever
+// after (audit A2).
+//
+// Waiting is the correct behaviour anyway. While it waits the loop does
+// not advance its cursor, /readyz reports 503 and the heartbeat falls
+// silent, so the external monitor alerts — that alerting is the
+// prerequisite that makes waiting acceptable rather than a silent stall.
+func (s *Sink) awaitConfirm(ctx context.Context, c confirmation, messageID string) error {
+	started := time.Now()
+	warn := time.NewTicker(confirmWarnEvery)
+	defer warn.Stop()
+
+	for {
 		select {
-		case ret := <-s.returns:
-			return fmt.Errorf("%w: broker returned %s unroutable (reply %d: %s) — is the consumer's queue bound?",
-				sink.ErrSinkUnroutable, env.MessageID, ret.ReplyCode, ret.ReplyText)
-		default:
+		case <-c.Done():
+			if !c.Acked() {
+				return fmt.Errorf("%w: broker nacked %s", sink.ErrSinkPublishRejected, messageID)
+			}
+			return nil
+		case <-warn.C:
+			log.Ctx(ctx).Warnf(
+				"Still waiting for the broker to confirm %s after %s — the ledger cursor is held until it answers",
+				messageID, time.Since(started).Round(time.Second))
+		case <-ctx.Done():
+			return ctx.Err()
 		}
-		return nil
-	case <-time.After(s.cfg.PublishConfirmTimeout):
-		return fmt.Errorf("%w: confirm timeout for %s", sink.ErrSinkPublishRejected, env.MessageID)
-	case <-ctx.Done():
-		return ctx.Err()
+	}
+}
+
+// checkReturned reports an unroutable publish. A returned message is
+// CONFIRMED (received but not routed), so the ack alone is not success.
+// Returns are matched by MessageId rather than assumed to belong to the
+// publish in flight: charging a stray return to the wrong envelope would
+// fail a perfectly routable message, the mirror image of A2.
+func (s *Sink) checkReturned(ctx context.Context, messageID string) error {
+	for {
+		select {
+		case ret, ok := <-s.returns:
+			if !ok {
+				// Closed along with the channel. Read as "nothing returned";
+				// the dead channel surfaces on the next publish.
+				return nil
+			}
+			if ret.MessageId != messageID {
+				log.Ctx(ctx).Warnf("Ignoring a basic.return for %s while publishing %s", ret.MessageId, messageID)
+				continue
+			}
+			return fmt.Errorf("%w: broker returned %s unroutable (reply %d: %s) — is the consumer's queue bound?",
+				sink.ErrSinkUnroutable, messageID, ret.ReplyCode, ret.ReplyText)
+		default:
+			return nil
+		}
 	}
 }
 
@@ -184,9 +296,9 @@ func (s *Sink) Publish(ctx context.Context, env events.Envelope) error {
 func (s *Sink) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.channel != nil {
-		_ = s.channel.Close()
-		s.channel = nil
+	if s.ch != nil {
+		_ = s.ch.Close()
+		s.ch = nil
 	}
 	if s.conn != nil {
 		err := s.conn.Close()

--- a/internal/sink/rabbitmq/rabbitmq_test.go
+++ b/internal/sink/rabbitmq/rabbitmq_test.go
@@ -1,0 +1,263 @@
+package rabbitmq
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+
+	"github.com/Trustless-Work/Indexer/internal/events"
+	"github.com/Trustless-Work/Indexer/internal/sink"
+)
+
+// fakeConfirmation stands in for *amqp.DeferredConfirmation, whose done
+// channel is unexported and therefore impossible to resolve from a test.
+// This is the whole reason the confirmation interface exists.
+type fakeConfirmation struct {
+	done chan struct{}
+	ack  bool
+}
+
+func newConfirmation() *fakeConfirmation {
+	return &fakeConfirmation{done: make(chan struct{})}
+}
+
+func (f *fakeConfirmation) Done() <-chan struct{} { return f.done }
+func (f *fakeConfirmation) Acked() bool           { return f.ack }
+
+// resolve answers this publish the way the broker would. Passing false
+// also models what the library does to every pending confirmation when
+// the channel or connection dies.
+func (f *fakeConfirmation) resolve(ack bool) {
+	f.ack = ack
+	close(f.done)
+}
+
+// fakeChannel hands out a pre-seeded confirmation per publish, in order,
+// so a test can decide independently how each message is answered.
+type fakeChannel struct {
+	answers  []*fakeConfirmation
+	sent     []string // routing keys, in publish order
+	messages []string // MessageId, in publish order
+	err      error
+	nilConf  bool // model a channel that is not in confirm mode
+}
+
+func (c *fakeChannel) publish(_ context.Context, routingKey string, msg amqp.Publishing) (confirmation, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	c.sent = append(c.sent, routingKey)
+	c.messages = append(c.messages, msg.MessageId)
+	if c.nilConf {
+		return nil, nil
+	}
+	next := c.answers[0]
+	c.answers = c.answers[1:]
+	return next, nil
+}
+
+func (c *fakeChannel) Close() error { return nil }
+
+func newSink(ch publishChannel, returns chan amqp.Return) *Sink {
+	if returns == nil {
+		returns = make(chan amqp.Return, returnsBuffer)
+	}
+	return &Sink{
+		cfg:     Config{Exchange: "stellar.events", PublisherConfirms: true},
+		ch:      ch,
+		returns: returns,
+	}
+}
+
+func envelope(id string) events.Envelope {
+	return events.Envelope{
+		SchemaVersion:   events.CurrentSchemaVersion,
+		Type:            "state",
+		Network:         "testnet",
+		ContractID:      "CAAA",
+		LedgerSeq:       42,
+		StateChangeType: "updated",
+		MessageID:       id,
+		RawXDR:          "AAAA",
+		PublishedAt:     time.Unix(1750000000, 0).UTC(),
+	}
+}
+
+// THE regression. Two publishes in a row where the FIRST is acked and the
+// SECOND nacked: the second must be judged by its OWN answer. The old
+// code read the next confirmation off a shared channel, so after any
+// desync it reported the second as delivered on the strength of the
+// first's ack — and the ingest loop advanced its cursor over a message
+// the broker had rejected.
+func TestPublish_EachMessageIsJudgedByItsOwnConfirmation(t *testing.T) {
+	first, second := newConfirmation(), newConfirmation()
+	ch := &fakeChannel{answers: []*fakeConfirmation{first, second}}
+	s := newSink(ch, nil)
+
+	first.resolve(true)   // the broker accepted message one
+	second.resolve(false) // and rejected message two
+
+	if err := s.Publish(context.Background(), envelope("one")); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+
+	err := s.Publish(context.Background(), envelope("two"))
+	if !errors.Is(err, sink.ErrSinkPublishRejected) {
+		t.Fatalf("second publish = %v, want ErrSinkPublishRejected — it must not inherit the first message's ack", err)
+	}
+}
+
+func TestPublish_AckedMessageSucceeds(t *testing.T) {
+	c := newConfirmation()
+	c.resolve(true)
+	ch := &fakeChannel{answers: []*fakeConfirmation{c}}
+	s := newSink(ch, nil)
+
+	if err := s.Publish(context.Background(), envelope("one")); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(ch.sent) != 1 || ch.sent[0] != "stellar.testnet.escrow.state.updated" {
+		t.Errorf("routing keys = %v, want the envelope's own key", ch.sent)
+	}
+	if len(ch.messages) != 1 || ch.messages[0] != "one" {
+		t.Errorf("message ids = %v, want [one]", ch.messages)
+	}
+}
+
+// A dead channel resolves every pending confirmation as a nack, which is
+// how the library reports it. That must surface as a rejection rather
+// than hang the loop forever.
+func TestPublish_ChannelDeathResolvesAsRejection(t *testing.T) {
+	c := newConfirmation()
+	ch := &fakeChannel{answers: []*fakeConfirmation{c}}
+	s := newSink(ch, nil)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		c.resolve(false) // what Channel.shutdown does to pending confirmations
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- s.Publish(context.Background(), envelope("one")) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, sink.ErrSinkPublishRejected) {
+			t.Fatalf("err = %v, want ErrSinkPublishRejected", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish hung on a confirmation the broker will never ack")
+	}
+}
+
+func TestPublish_ContextCancellationUnblocksTheWait(t *testing.T) {
+	ch := &fakeChannel{answers: []*fakeConfirmation{newConfirmation()}} // never resolved
+	s := newSink(ch, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err := s.Publish(ctx, envelope("one"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+}
+
+// A returned message is confirmed by the broker, so the ack alone is not
+// success — the envelope reached no queue at all.
+func TestPublish_ReturnedMessageIsUnroutable(t *testing.T) {
+	c := newConfirmation()
+	c.resolve(true)
+	ch := &fakeChannel{answers: []*fakeConfirmation{c}}
+	returns := make(chan amqp.Return, returnsBuffer)
+	returns <- amqp.Return{MessageId: "one", ReplyCode: 312, ReplyText: "NO_ROUTE"}
+	s := newSink(ch, returns)
+
+	err := s.Publish(context.Background(), envelope("one"))
+	if !errors.Is(err, sink.ErrSinkUnroutable) {
+		t.Fatalf("err = %v, want ErrSinkUnroutable", err)
+	}
+}
+
+// The mirror image of A2: a return belonging to some other envelope must
+// not fail this one. Charging it here would kill a perfectly routable
+// message and, worse, mask the fact that a DIFFERENT one was dropped.
+func TestPublish_ForeignReturnIsNotChargedToThisMessage(t *testing.T) {
+	c := newConfirmation()
+	c.resolve(true)
+	ch := &fakeChannel{answers: []*fakeConfirmation{c}}
+	returns := make(chan amqp.Return, returnsBuffer)
+	returns <- amqp.Return{MessageId: "somebody-else", ReplyCode: 312, ReplyText: "NO_ROUTE"}
+	s := newSink(ch, returns)
+
+	if err := s.Publish(context.Background(), envelope("one")); err != nil {
+		t.Fatalf("Publish = %v, want success: the return belongs to another envelope", err)
+	}
+}
+
+// A closed returns channel must not spin: reading it yields zero values
+// forever, and a drain loop that only skips on a MessageId mismatch would
+// never terminate.
+func TestPublish_ClosedReturnsChannelDoesNotSpin(t *testing.T) {
+	c := newConfirmation()
+	c.resolve(true)
+	ch := &fakeChannel{answers: []*fakeConfirmation{c}}
+	returns := make(chan amqp.Return)
+	close(returns)
+	s := newSink(ch, returns)
+
+	done := make(chan error, 1)
+	go func() { done <- s.Publish(context.Background(), envelope("one")) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Publish = %v, want success", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish spun on a closed returns channel")
+	}
+}
+
+// Confirm mode off is fire-and-forget: the library reports it with a nil
+// confirmation, and there is nothing to wait on.
+func TestPublish_WithoutConfirmModeReturnsImmediately(t *testing.T) {
+	ch := &fakeChannel{nilConf: true}
+	s := newSink(ch, nil)
+
+	if err := s.Publish(context.Background(), envelope("one")); err != nil {
+		t.Fatalf("Publish = %v, want success", err)
+	}
+	if len(ch.messages) != 1 {
+		t.Errorf("published %d messages, want 1", len(ch.messages))
+	}
+}
+
+func TestPublish_InvalidEnvelopeNeverReachesTheBroker(t *testing.T) {
+	ch := &fakeChannel{}
+	s := newSink(ch, nil)
+
+	err := s.Publish(context.Background(), events.Envelope{Type: "state"}) // missing everything else
+	if !errors.Is(err, events.ErrEnvelopeInvalid) {
+		t.Fatalf("err = %v, want ErrEnvelopeInvalid", err)
+	}
+	if len(ch.sent) != 0 {
+		t.Errorf("a malformed envelope was published: %v", ch.sent)
+	}
+}
+
+func TestPublish_TransportFailureIsUnavailable(t *testing.T) {
+	ch := &fakeChannel{err: errors.New("channel closed")}
+	s := newSink(ch, nil)
+
+	err := s.Publish(context.Background(), envelope("one"))
+	if !errors.Is(err, sink.ErrSinkUnavailable) {
+		t.Fatalf("err = %v, want ErrSinkUnavailable", err)
+	}
+}

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -43,10 +43,12 @@ var (
 	// crash-restart) can recover.
 	ErrSinkUnavailable = errors.New("sink unavailable")
 	// ErrSinkPublishRejected signals the broker explicitly rejected the
-	// publish (a nack — e.g. a full queue with a reject-publish overflow
-	// policy — or a confirm timeout). The channel stays usable, so this
-	// IS the class a caller may retry with backoff: backpressure, not
-	// breakage.
+	// publish: a nack, e.g. a full queue with a reject-publish overflow
+	// policy. The channel stays usable, so this IS the class a caller may
+	// retry with backoff: backpressure, not breakage. A slow broker no
+	// longer lands here — a publish now waits for its own confirmation
+	// however long that takes, instead of giving up and letting the late
+	// answer be charged to the next message (audit A2).
 	ErrSinkPublishRejected = errors.New("sink publish rejected")
 	// ErrSinkUnroutable signals the broker accepted the publish but no
 	// queue was bound to receive it (basic.return on a mandatory


### PR DESCRIPTION
Closes audit finding A2 (TWH-730), the last of the three highs.

## The bug

`Publish` took the next confirmation off a shared channel and assumed it belonged to the message just sent — **it never checked**. That assumption held until one confirmation took longer than the 10s timeout: `Publish` gave up, the late answer stayed queued, and from then on every publish read the *previous* message's answer. Permanent, because the channel is never rebuilt.

It is silent data loss. A confirmation says accepted or rejected, and rejection is routine here — the queue policy rejects publishes at 50,000 messages. Reading one behind, a rejected message was reported as delivered and the loop advanced its cursor past it. Reproduced deterministically before the fix.

## The fix

Correlation by **identity** instead of by position: each publish waits on its own `DeferredConfirmation`.

Three things follow from that:

- **`NotifyPublish` is removed**, which kills a second hazard. The library delivers confirmations with a *blocking* send, so a listener nobody drains stalls the connection dispatcher, kills the heartbeats and drops the connection — precisely while a publish sits in backoff. With no listener registered, that loop has nobody to block.
- **The timeout is removed**, since it was the desync source. Verified in the library source that this is safe: `Channel.shutdown()` nacks every pending deferred confirmation and closes its `done`, so one always resolves — by ack, by nack, or because the channel died. The threshold survives as a periodic warning that never abandons the wait.
- **Returns are matched by `MessageId`.** Charging a stray return to the wrong envelope is the mirror image of this bug: it fails a routable message and masks the loss of another.

## Testability came first

The package had **no tests at all**, and that was not incidental: the channel was a concrete `*amqp.Channel`, and a fake cannot resolve an `amqp.DeferredConfirmation` whose `done` is private. Two small interfaces fix that — `*amqp.DeferredConfirmation` satisfies `confirmation` as-is, no wrapper. `connect()` stays outside the seam: it is boot wiring, and abstracting it would inflate the diff without buying coverage.

10 tests. The central one states the property directly rather than recreating the timeout: two publishes where the first is acked and the second nacked — the second must fail. The old code returned success for it.

## Also

`PublishConfirmTimeout` is deleted from config. It was dead (the factory never passed it, so it was always 10s — part of finding B6) and as a mere log threshold it does not deserve config surface. The `returns` buffer goes from 1 to 8: it carries the same blocking-send hazard as `NotifyPublish`, and it made no sense to remove one and leave its twin.

## Verification

`gofmt`, `go vet`, `go build`, `go test` and `go test -race` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RabbitMQ publishing now tracks confirmations per message for more accurate delivery results.
  * Publishing waits for broker confirmation without an artificial timeout.
  * Context cancellation can interrupt pending publishes.
  * Unroutable messages are detected and reported reliably.
  * Publishing without confirmation enabled remains immediate and fire-and-forget.

* **Bug Fixes**
  * Prevented acknowledgements or rejections from being attributed to the wrong message.
  * Improved handling of broker disconnects and pending confirmations.
  * Clarified retry and publish rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->