### PR TITLE
chore(agents): version agent context, skills and guardrails in the repo

### DIFF
--- a/.claude/hooks/block-push-main.sh
+++ b/.claude/hooks/block-push-main.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# PreToolUse hook (Bash): refuse `git push` that targets main.
+# Work lands on main only through a GitHub PR + merge (see CLAUDE.md > Workflow).
+# Reads the tool call JSON on stdin; exit 2 blocks the call and shows stderr to the agent.
+cmd=$(node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).tool_input.command||"")}catch{}})')
+case "$cmd" in
+  *"git push"*)
+    # explicit main target
+    if printf '%s' "$cmd" | grep -Eq 'git push[^;&|]*(\s|:)(main|origin/main)(\s|$)'; then
+      echo "Blocked: pushing to main directly. Push the feature branch and open a PR." >&2
+      exit 2
+    fi
+    # bare `git push` while checked out on main
+    if ! printf '%s' "$cmd" | grep -Eq 'git push\s+\S+\s+\S+'; then
+      if [ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" = "main" ]; then
+        echo "Blocked: you are on main. Create a branch and open a PR instead." >&2
+        exit 2
+      fi
+    fi
+    ;;
+esac
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go test *)",
+      "Bash(go vet *)",
+      "Bash(go build *)",
+      "Bash(gofmt -l *)",
+      "Bash(make test*)",
+      "Bash(make vet*)",
+      "Bash(make build*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git branch*)",
+      "Bash(git show*)"
+    ],
+    "deny": [
+      "Bash(rm * indexer.state*)",
+      "Bash(make reset-state*)",
+      "Bash(railway *)",
+      "Read(./.env)",
+      "Read(./indexer.state.json)",
+      "Read(./indexer.watchlist.seed.json)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-push-main.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/envelope-contract-change/SKILL.md
+++ b/.claude/skills/envelope-contract-change/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: envelope-contract-change
+description: How to change what the Indexer publishes — envelope fields, schema_version, message ids, routing keys, exchange or fact types — without silently breaking the core API that consumes it. Use when touching internal/events, internal/sink/rabbitmq, docs/event-schema.md, or adding a new fact/processor whose output reaches the broker.
+---
+
+# Envelope contract change
+
+The envelope is a **shared contract with `trustlesswork-core-api`**. That repo's
+ingestion consumer (`src/presentation/ingestion`, `src/application/ingestion`) parses
+exactly the shape in `docs/event-schema.md` and dedupes on `message_id`. The two repos
+deploy independently, so a change here can be live for hours before the consumer knows.
+
+## Non-negotiables
+
+- **Thin indexer, smart consumer.** Forward raw XDR. If a change needs the indexer to
+  decode escrow-specific data (amounts, milestones, roles), stop — that logic belongs in
+  the consumer.
+- **`message_id` is deterministic and is the idempotency key.** Changing how it is built
+  (`NewMessageID`, `NewStateMessageID`, `NewGapMessageID` in
+  `internal/events/envelope.go`) changes identity: replays stop deduping against
+  history. Do it only with a schema bump and a stated migration for the consumer.
+- **Total order key** (`ledger_seq`, `tx_index`, `event_index`) must remain present
+  and comparable.
+
+## Procedure
+
+1. **Classify the change.**
+   - *Additive* (new optional field, new fact `type` the consumer can ignore): minor
+     bump of `CurrentSchemaVersion` (`1.1` → `1.2`).
+   - *Breaking* (renamed/removed field, changed semantics, changed `message_id`
+     derivation, new required field, new routing key the consumer must bind): major
+     bump, and the consumer must ship first or in lockstep. Say which in the PR.
+2. **Update `docs/event-schema.md` in the same PR** — field table, example JSON,
+   routing keys. The spec and the code must never disagree at any commit. (Ignore the
+   stale "Status" block at the top unless you are removing it.)
+3. **Update `CHANGELOG.md` `[Unreleased]`** with the schema version and the
+   consumer-facing effect.
+4. **Cover it in `internal/events` tests** (shape, ids, version) and in
+   `internal/sink/rabbitmq` tests if routing/headers changed.
+5. **Replay is part of the contract.** `indexer replay` re-publishes events/deposits of
+   a range with the SAME ids; the consumer must dedupe old and new copies. If the change
+   makes replayed messages differ from originally published ones, that is breaking.
+6. **Coordinate the consumer.** Open (or describe in the PR) the matching change in
+   core-api and the deploy order. Never merge a breaking envelope change with a
+   "the core will catch up" note.
+
+## Done when
+
+Schema version bumped correctly, spec + changelog updated in the same PR, tests cover
+the new shape, and the PR body names the consumer change and the deploy order.

--- a/.claude/skills/finish-work/SKILL.md
+++ b/.claude/skills/finish-work/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: finish-work
+description: Closing package for a finished unit of work in this repo — commit message, PR title/body and merge title/body, in English, pasteable as-is. Use when the user says the work is done, asks to close a sprint/task, or asks for a commit/PR message.
+---
+
+# Finish work — the closing package
+
+The user commits, pushes and merges by hand. Your deliverable is the TEXT, complete and
+in this exact order. A one-line commit suggestion alone is an incomplete deliverable.
+
+## 0. Preconditions (run, do not assume)
+
+- `gofmt -l .` prints nothing; `go vet ./...`, `CGO_ENABLED=0 go build ./...`, `go test ./...` are green.
+  If any is red, say so with the output and stop — do not produce the package.
+- `git status` shows only intended files. Mention anything unexpected.
+- `CHANGELOG.md` `[Unreleased]` has an entry if the change is user-visible or operational.
+- The branch is NOT `main`. If it is, stop: work must land via PR.
+
+## 1. Commit — repo name in the heading
+
+Give the commands verbatim:
+
+```bash
+git add .
+git commit -m "<subject>
+
+<body>"
+git push -u origin <branch>
+```
+
+Rules for the `-m` string — it is pasted into a shell:
+- **No double quotes, single quotes, apostrophes or backticks anywhere inside it.**
+  Write "do not" instead of "don't"; name identifiers plainly without backticks.
+- Subject: conventional commit (`feat|fix|chore|docs|security|refactor|test(scope): ...`),
+  imperative, ≤ 72 chars.
+- Body: one paragraph of reasoning/scope decisions; then one bullet per change; a
+  `Deferred:` section if anything was consciously left out; a final `Tests:` line
+  (packages tested + gofmt/vet clean).
+- If the work maps to audit finding IDs or a sprint tag, name them in the body.
+
+## 2. Pull Request — title
+
+Same conventional prefix as the commit subject; add the sprint tag if there is one.
+
+## 3. Pull Request — description
+
+Sections, in order (quotes and backticks are fine here):
+
+- `## Context` — why now, predecessors, scope decisions.
+- `## What it resolves` — bullet per change; bold the finding ID when there is one.
+- `## Deferred` — what was left out and why (omit section if nothing).
+- `## Testing` — what was run and the result.
+
+## 4. Merge — title and description
+
+Title = PR title. Description = 3–5 line summary suitable for `git log`.
+
+## Hard rules (repo-wide)
+
+- **English** for every git artefact, even if the conversation is in Spanish.
+- **No AI attribution anywhere**: no `Co-Authored-By: Claude`, no "generated with",
+  no mention of assistants in commit, PR, merge or code. The work must read as fully human.
+- Close with the status: what is merged/pending and what the next step is.

--- a/.claude/skills/ops-runbook/SKILL.md
+++ b/.claude/skills/ops-runbook/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ops-runbook
+description: Operating a running Indexer without a redeploy — reseed after state loss, replay a ledger range, pause/resume, reconcile, inspect status, reset local state — and the actions that cause silent data loss. Use when the user asks to fix a gap, recover the watchlist, redo a range, check why escrows are missing, or run anything against the Railway indexer.
+---
+
+# Ops runbook
+
+Everything here is operator-driven. The agent prepares the exact commands and explains
+what they will do; the user runs anything that touches Railway or holds a token.
+`docs/control-plane.md` is the design; `README.md` documents `/status` fields.
+
+## First: read the numbers
+
+`GET /status` on the health port (`:8080`, private) — cursor, ledger age, active
+`rpc_endpoint`, pause state, escrows tracked, publish totals, recorded gaps,
+`suppressed_removals`, uptime. On Railway:
+`railway ssh -- "wget -qO- localhost:8080/status"` (ONE quoted string; `railway ssh`
+flattens arguments and drops inner quoting — no `sh -c`, no nested quotes).
+
+Interpretation:
+- `suppressed_removals > 0` → an RPC endpoint answered empty; look at the endpoint,
+  not at the escrows (audit A3 guard).
+- ledger age growing with a healthy endpoint → check the core's queue depth; the
+  publisher waits on confirms and backpressure is by design.
+- gaps recorded → those ranges were skipped ON PURPOSE with evidence; backfill with
+  replay. Ranges NOT recorded (see below) are the dangerous ones.
+
+## Silent-loss actions — never do these casually
+
+- First boot / new volume with `INDEXER_START_LEDGER=0`: starts at the tip, indexes
+  nothing before, records no gap. Set the start ledger explicitly on any fresh state.
+- A WASM hash missing from `ESCROW_APPROVED_WASM_HASHES`: that contract version is
+  invisible (zero envelopes, zero logs). Verify the list against the deployed contract
+  hashes before concluding "no activity".
+- `rm` the state file while the process runs: the loop rewrites it every ledger. Stop
+  and remove atomically: `railway ssh -- "rm -f /var/lib/indexer/<state> && kill -TERM 1"`.
+- Local: `make reset-state` wipes the docker state volume; `make run` and `make up`
+  both bind :8080.
+
+## Procedures
+
+**Recover the watchlist after state loss** (control-plane.md "Recovering after state loss"):
+1. In core-api: `scripts/export-escrow-seed.ts` → contract ids currently in the read-model.
+2. `POST /admin/reseed` (bearer `ADMIN_TOKEN`) with those ids, or set `ESCROW_SEED_PATH`
+   to an uploaded file for boot-time seeding.
+3. The reconciliation sweep's next pass fetches state for all of them; confirm in
+   `/status` (escrows tracked) and in the core's read-model.
+
+**Backfill a range** (recorded gap, DLQ loss on the core side, or a re-project):
+`bin/ingest replay --from N --to M` — runs NEXT TO the live indexer, persists nothing,
+takes no lock, no heartbeat, events/deposits only (no state snapshots). It refuses ranges
+no configured endpoint serves in full; today the check uses `getHealth.OldestLedger`
+(known limit — some providers serve more via `getLedgers`). Point `RPC_FALLBACK_URLS` at
+an archive provider for old history. Downstream dedupe absorbs duplicates.
+
+**Track / remove / refresh one escrow:** `/admin/escrows` (POST/DELETE) — validates and
+enqueues; `202` means queued, the loop executes between ledgers.
+
+**Pause / resume:** `/admin/pause` (TTL-bounded, always expires) and `/admin/resume`.
+
+**Force a reconciliation pass:** `POST /admin/reconcile`. Reconcile SETS (what should be
+tracked vs what is), never replay events through the control plane.
+
+**Never:** propose a broker-based command channel (removed, audit A1), expose the health
+port publicly, or run two live indexers against the same state volume.
+
+## Done when
+
+The user has run the commands, `/status` reflects the expected change, and — if the goal
+was data in the read-model — the core's tables show it (eventually consistent, ~1–2 s).

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ indexer.watchlist.seed.json
 /indexer
 /ingest
 bin/
+# AI assistant per-machine state (shared context in .claude/ is versioned)
+.claude/settings.local.json
+.claude/launch.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# Trustless Work Indexer — agent context
+
+Go service that follows the Stellar ledger stream, detects activity on Trustless Work
+escrow contracts and publishes versioned envelopes to RabbitMQ for the core API.
+`README.md` is the operator onboarding (pipeline, failover, health, replay, deploy) —
+read it once. This file holds only what is NOT derivable from the code.
+
+## Purpose (this is the design criterion, not the README blurb)
+
+Reading ledgers is the mechanism. The purpose is to be **the source of truth for
+everything on-chain that concerns us**, so that any fact can be traced back to the
+ledger if it ever has to be. Derived rule for every design decision: *deliver, from
+every ledger, everything that concerns us, and keep the ability to redefine "concerns
+us" backwards in time.* That is stricter than "do not lose messages": a silent gap is
+a failure even if nothing was technically lost. The service must do ONE thing, perfectly.
+
+## Invariants (do not break; each one exists because of an incident or an audit finding)
+
+- **The ingest loop is the single writer** of the watchlist and the state files.
+  Commands from `/admin/*` only validate and enqueue; the loop executes them between
+  ledgers. Never write state from another goroutine, handler or subcommand.
+- **At-least-once with deterministic `message_id`s** (`internal/events/envelope.go`);
+  the consumer dedupes. The cursor **never advances past an unpublished fact** —
+  publisher confirms are awaited per message (audit A2).
+- **Removals need evidence.** An empty RPC answer for a batch never publishes the batch
+  as removed (audit A3, `suppressed_removals` in `/status`).
+- **No AMQP command channel.** It was removed (audit A1); the only door in is the
+  bearer-authenticated `/admin/*` HTTP surface, which must never be public. Any proposal
+  of "let the core publish a message to the indexer over the broker" reopens A1 — the
+  answer is pull, not push, and reconcile sets, not events (`docs/control-plane.md`).
+- **Thin indexer, smart consumer.** Forward raw XDR; never decode escrow-specific data
+  here. Identity is by approved WASM hash, never by address list or topic enumeration.
+- **Chain continuity by parent hash** on resume and on endpoint rotation; a fallback
+  serving a different chain must be fatal, not tolerated.
+
+## Shared contract with core-api
+
+The envelope shape (`schema_version` currently `1.1`), routing keys and the
+`stellar.events` exchange are consumed by `trustlesswork-core-api`
+(`src/presentation/ingestion` + `src/application/ingestion`). A change here is a change
+there. `docs/event-schema.md` is the spec — its opening "Status" block is stale (it says
+the indexer does not publish yet; it has for months); the shape sections are current.
+See `.claude/skills/envelope-contract-change`.
+
+## Silent-loss modes (nothing in Postgres, nothing in the gap record)
+
+- `INDEXER_START_LEDGER=0` on a **first boot** (or after losing the state volume) means
+  "start at the tip": everything before is never indexed and NO gap is recorded.
+- A contract whose WASM hash is not in `ESCROW_APPROVED_WASM_HASHES` is invisible:
+  zero envelopes, zero logs.
+- Deleting the state file while the process runs: the loop rewrites it every ledger.
+  Remove it and stop pid 1 atomically (`rm -f ... && kill -TERM 1`), never rm-then-redeploy.
+- Messages parked in the core's DLQ are the core's problem to redrive, but the indexer
+  side of the story is `indexer replay --from N --to M`.
+
+## Known limits (true today; fix deliberately, not in passing)
+
+- `internal/ingest/failover.go` clamps the start ledger using `getHealth`'s
+  `OldestLedger`, but several providers serve far more history through `getLedgers`.
+  So `replay` can refuse a range the endpoint would actually serve — with an error that
+  suggests using an archive endpoint even when the rejected endpoint IS archive.
+- The `datastore` package (S3/GCS ledger lake) is wired but unused; the `aws-sdk-go-v2`
+  findings from govulncheck enter through it. Implementing it makes them real deps.
+- Mainnet needs `INDEXER_GET_LEDGERS_LIMIT=10` (with 100 catch-up asks ~265 MB per
+  answer). RPC plan decided: Validation Cloud primary + free archive fallbacks.
+  Testnet has no free public ledger lake; deep testnet history may cost more than mainnet.
+
+## Environments and operations
+
+- Prod: Railway, one project with the broker; state on a mounted volume (`STATE_PATH`).
+  `railway ssh -- CMD` flattens arguments — pass compound commands as ONE quoted string.
+- The testnet indexer stays as a permanent canary after mainnet go-live.
+- Local `make run` and `make up` both bind :8080 — stop one before the other.
+- Ops procedures (reseed, replay, pause, state reset): `.claude/skills/ops-runbook`.
+
+## Workflow
+
+- Every change starts on a new branch from `main` and lands through a GitHub PR + merge.
+  Never push to `main` directly. `main` is the deployed branch (Railway, testnet today;
+  mainnet later — see core-api's branch plan, mirrored here when it lands).
+- Definition of done: `gofmt -l .` prints nothing, `go vet ./...`,
+  `CGO_ENABLED=0 go build ./...`, `go test ./...` green. Update `CHANGELOG.md`
+  (`[Unreleased]`) for anything user-visible or operational.
+- Code, comments, docs and ALL git artefacts are in **English**, even when the
+  conversation is in Spanish. No AI trailers or mentions anywhere.
+  See `.claude/skills/finish-work` for the closing package.
+- Auxiliary tooling lives in a SEPARATE repo, never under this one. Ask where first.
+- Sibling repos: `trustlesswork-core-api` (consumer), `trustlesswork-probe` (e2e against
+  deployed environments; measures indexer→read-model lag, ~0.6 s on testnet).
+- `.claude/skills/{assets,data,smart-contracts}` are Stellar reference skills, kept for
+  contributors without the Anthropic Stellar plugin. Project procedures are the others.


### PR DESCRIPTION
## Context

Second repo to adopt the agent-context layout introduced in
`trustlesswork-core-api` (CLAUDE.md + on-demand skills + enforced guardrails). The
indexer's README and `docs/` already explain *how* it works; this adds what an agent
cannot derive from code: the declared purpose behind the design, the audit-born
invariants, the shared envelope contract with core-api, and the operations that lose
data silently.

Scope decisions:
- `CLAUDE.md` is facts only (~90 lines). Procedures are skills that load when relevant.
- Non-negotiables (no push to `main`, no `railway` from an agent, no removing the state
  file, no reading `.env`/state) are enforced in `.claude/settings.json` and a hook.
- The three Stellar reference skills already versioned under `.claude/skills` are kept.
- English throughout, matching the codebase.

## What it resolves

- **CLAUDE.md** — purpose as design criterion; invariants tied to **A1** (no AMQP
  command channel), **A2** (confirmed publishes, cursor never past an unpublished
  fact), **A3** (removal evidence guard), single-writer loop, thin indexer, chain
  continuity; shared contract with core-api; silent-loss modes; known limits
  (`failover.go` `getHealth` clamp, unused datastore, mainnet `GET_LEDGERS_LIMIT`);
  ops notes; workflow and definition of done.
- **`finish-work` skill** — closing package format, Go definition of done, changelog
  check. Same content as core-api's; second occurrence.
- **`envelope-contract-change` skill** — additive vs breaking, `schema_version` bump,
  spec + changelog in the same PR, `message_id` as identity, replay as part of the
  contract, consumer deploy order.
- **`ops-runbook` skill** — `/status` first, silent-loss actions, reseed after state
  loss, replay a range, track/pause/reconcile, `railway ssh` quoting.
- **`.claude/settings.json` + hook** — allow list for gofmt/vet/build/test and read-only
  git; deny `railway *`, state-file removal, `make reset-state`, `.env`/state reads;
  `PreToolUse` hook blocking pushes to `main`.
- **`.gitignore`** — ignores `.claude/settings.local.json` and `.claude/launch.json`.

## Deferred

- `docs/event-schema.md` opening "Status" block is stale (says the indexer does not
  publish yet). Flagged in `CLAUDE.md`; remove in a docs pass.
- Promote `finish-work` + hook to a cross-repo plugin at the third repo.

## Testing

- `gofmt -l .` empty, `go vet ./...` clean, `CGO_ENABLED=0 go build ./...` ok.
- `go test ./...`: 9/9 packages green.
- Hook tested by hand: blocks `git push origin main`.
- No CHANGELOG entry: nothing about the binary or its operation changed.